### PR TITLE
Fix linker issues for shared build on Windows.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -92,3 +92,7 @@ class ProtobufConan(ConanFile):
             self.cpp_info.libs.append("pthread")
             if self._is_clang_x86():
                 self.cpp_info.libs.append("atomic")
+
+        if self.settings.os == "Windows":
+            if self.options.shared:
+                self.cpp_info.defines = ["PROTOBUF_USE_DLLS"]


### PR DESCRIPTION
When building protobuf as a shared library on Windows (VS 2017), linker errors similar to the ones reported in [protobuf issue 2502](https://github.com/protocolbuffers/protobuf/issues/2502). As mentioned in issue 2502, adding the `PROTOBUF_USE_DLLS` compiler definition fixes the linker errors.