### PR TITLE
Fix protobuf.patch to support protobuf_BUILD_PROTOC_BINARIES

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -65,7 +65,7 @@ class ProtobufConan(ConanFile):
         return cmake
 
     def build(self):
-        #tools.patch(base_path=self._source_subfolder, patch_file="protobuf.patch")
+        tools.patch(base_path=self._source_subfolder, patch_file="protobuf.patch")
         tools.patch(base_path=self._source_subfolder, patch_file="fix-missing-include-file.patch")
         cmake = self._configure_cmake()
         cmake.build()

--- a/protobuf.patch
+++ b/protobuf.patch
@@ -1,152 +1,79 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 02174e9..828d46c 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
-@@ -28,6 +28,7 @@ endif()
+@@ -14,6 +14,7 @@
+ # Options
  option(protobuf_BUILD_TESTS "Build tests" ON)
  option(protobuf_BUILD_EXAMPLES "Build examples" OFF)
- option(protobuf_BUILD_PROTOC_BINARIES "Build libprotoc and protoc compiler" ON)
-+option(protobuf_BUILD_PROTOBUF_LITE "Build libprotobuf-lite" ON)
++option(protobuf_BUILD_PROTOC_BINARIES "Build libprotoc and protoc compiler" ON)
  if (BUILD_SHARED_LIBS)
    set(protobuf_BUILD_SHARED_LIBS_DEFAULT ON)
  else (BUILD_SHARED_LIBS)
-@@ -192,11 +193,16 @@ if (protobuf_UNICODE)
-   add_definitions(-DUNICODE -D_UNICODE)
- endif (protobuf_UNICODE)
- 
--include(libprotobuf-lite.cmake)
--include(libprotobuf.cmake)
-+if (protobuf_BUILD_PROTOBUF_LITE)
-+  include(libprotobuf-lite.cmake)
-+endif (protobuf_BUILD_PROTOBUF_LITE)
-+
-+if (protobuf_BUILD_PROTOC_BINARIES OR NOT protobuf_BUILD_PROTOBUF_LITE)
-+  include(libprotobuf.cmake)
-+endif (protobuf_BUILD_PROTOC_BINARIES OR NOT protobuf_BUILD_PROTOBUF_LITE)
-+
- if (protobuf_BUILD_PROTOC_BINARIES)
-   include(libprotoc.cmake)
--  include(protoc.cmake)
- endif (protobuf_BUILD_PROTOC_BINARIES)
- 
+@@ -165,8 +166,10 @@
+
+ include(libprotobuf-lite.cmake)
+ include(libprotobuf.cmake)
+-include(libprotoc.cmake)
+-include(protoc.cmake)
++if (protobuf_BUILD_PROTOC_BINARIES)
++  include(libprotoc.cmake)
++  include(protoc.cmake)
++endif (protobuf_BUILD_PROTOC_BINARIES)
+
  if (protobuf_BUILD_TESTS)
+   include(tests.cmake)
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index 82036cb..5b8506a 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -5,7 +5,16 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf.pc.cmake
- configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf-lite.pc.cmake
-                ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc @ONLY)
- 
--set(_protobuf_libraries libprotobuf-lite libprotobuf)
-+set(_protobuf_libraries)
+@@ -1,9 +1,11 @@
+ include(GNUInstallDirs)
+
+-foreach(_library
+-  libprotobuf-lite
+-  libprotobuf
+-  libprotoc)
++set(_protobuf_libraries libprotobuf-lite libprotobuf)
++if (protobuf_BUILD_PROTOC_BINARIES)
++    list(APPEND _protobuf_libraries libprotoc)
++endif (protobuf_BUILD_PROTOC_BINARIES)
 +
-+if (protobuf_BUILD_PROTOBUF_LITE)
-+  list(APPEND _protobuf_libraries libprotobuf-lite)
-+endif (protobuf_BUILD_PROTOBUF_LITE)
-+
-+if (NOT protobuf_BUILD_PROTOBUF_LITE)
-+  list(APPEND _protobuf_libraries libprotobuf)
-+endif ()
-+
- if (protobuf_BUILD_PROTOC_BINARIES)
-     list(APPEND _protobuf_libraries libprotoc)
- endif (protobuf_BUILD_PROTOC_BINARIES)
-@@ -21,11 +30,6 @@ foreach(_library ${_protobuf_libraries})
++foreach(_library ${_protobuf_libraries})
+   set_property(TARGET ${_library}
+     PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+     $<BUILD_INTERFACE:${protobuf_source_dir}/src>
+@@ -14,8 +16,10 @@
      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
  endforeach()
- 
--if (protobuf_BUILD_PROTOC_BINARIES)
--  install(TARGETS protoc EXPORT protobuf-targets
--    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
--endif (protobuf_BUILD_PROTOC_BINARIES)
--
- install(FILES ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
- 
+
+-install(TARGETS protoc EXPORT protobuf-targets
+-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
++if (protobuf_BUILD_PROTOC_BINARIES)
++  install(TARGETS protoc EXPORT protobuf-targets
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
++endif (protobuf_BUILD_PROTOC_BINARIES)
+
  file(STRINGS extract_includes.bat.in _extract_strings
-@@ -105,18 +109,10 @@ configure_file(protobuf-options.cmake
+   REGEX "^copy")
+@@ -94,10 +98,18 @@
    ${CMAKE_INSTALL_CMAKEDIR}/protobuf-options.cmake @ONLY)
- 
+
  # Allows the build directory to be used as a find directory.
--
--if (protobuf_BUILD_PROTOC_BINARIES)
--  export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
--    NAMESPACE protobuf::
--    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
--  )
--else (protobuf_BUILD_PROTOC_BINARIES)
--  export(TARGETS libprotobuf-lite libprotobuf
--    NAMESPACE protobuf::
--    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
--  )
--endif (protobuf_BUILD_PROTOC_BINARIES)
-+export(TARGETS ${_protobuf_libraries}
-+  NAMESPACE protobuf::
-+  FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
-+)
- 
+-export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
+-  NAMESPACE protobuf::
+-  FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+-)
++
++if (protobuf_BUILD_PROTOC_BINARIES)
++  export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
++    NAMESPACE protobuf::
++    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
++  )
++else (protobuf_BUILD_PROTOC_BINARIES)
++  export(TARGETS libprotobuf-lite libprotobuf
++    NAMESPACE protobuf::
++    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
++  )
++endif (protobuf_BUILD_PROTOC_BINARIES)
+
  install(EXPORT protobuf-targets
    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
-diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
-index 65d05c1..c3fc7d9 100644
---- a/cmake/libprotobuf.cmake
-+++ b/cmake/libprotobuf.cmake
-@@ -112,9 +112,41 @@ set(libprotobuf_includes
-   ${protobuf_source_dir}/src/google/protobuf/wrappers.pb.h
- )
- 
-+set(libprotobuf_lite_files
-+  ${protobuf_source_dir}/src/google/protobuf/arena.cc
-+  ${protobuf_source_dir}/src/google/protobuf/arenastring.cc
-+  ${protobuf_source_dir}/src/google/protobuf/extension_set.cc
-+  ${protobuf_source_dir}/src/google/protobuf/generated_message_table_driven_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/generated_message_util.cc
-+  ${protobuf_source_dir}/src/google/protobuf/implicit_weak_message.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/coded_stream.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream_impl_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/message_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/repeated_field.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/bytestream.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/common.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/int128.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/io_win32.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/status.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/statusor.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/stringpiece.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/stringprintf.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/structurally_valid.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/strutil.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/time.cc
-+  ${protobuf_source_dir}/src/google/protobuf/wire_format_lite.cc
-+)
-+
- add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
-   ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes})
--target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
-+
-+string(FIND "${CMAKE_LIBRARY_ARCHITECTURE}" "arm" ARM_CROSSCOMPILING)
-+if (${ARM_CROSSCOMPILING} GREATER -1)
-+    target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} atomic)
-+else()
-+    target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
-+endif()
- if(protobuf_WITH_ZLIB)
-     target_link_libraries(libprotobuf ${ZLIB_LIBRARIES})
- endif()
-diff --git a/cmake/protoc.cmake b/cmake/protoc.cmake
-index 5777b16..45c9d4f 100644
---- a/cmake/protoc.cmake
-+++ b/cmake/protoc.cmake
-@@ -3,5 +3,10 @@ set(protoc_files
- )
- 
- add_executable(protoc ${protoc_files})
--target_link_libraries(protoc libprotobuf libprotoc)
-+# Clang x86 requires atomic lib
-+if (${CMAKE_SIZEOF_VOID_P} EQUAL 4 AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT ${CMAKE_LIBRARY_ARCHITECTURE})
-+    target_link_libraries(protoc libprotobuf libprotoc atomic)
-+else ()
-+    target_link_libraries(protoc libprotobuf libprotoc)
-+endif ()
- add_executable(protobuf::protoc ALIAS protoc)


### PR DESCRIPTION
Patch updated based on PR https://github.com/protocolbuffers/protobuf/pull/3878/

Tested locally for:
 - Cross-build from 'Macos:x86_64' to 'Android:armv7hf'