### PR TITLE
Fix library declaration order

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -76,6 +76,7 @@ class ProtobufConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.libs.sort(reverse=True)
 
         if self.settings.os == "Linux":
             self.cpp_info.libs.append("pthread")


### PR DESCRIPTION
- When linking protobuf to protoc, libprotoc must be listed first.
  Otherwise a link error will occur when building protoc executable.

Signed-off-by: Uilian Ries <uilianries@gmail.com>