### PR TITLE
Fix build options

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -13,11 +13,14 @@ class ConanFileDefault(ConanFileBase):
     options = {"shared": [True, False],
                "with_zlib": [True, False],
                "fPIC": [True, False],
-               "lite": [True, False]}
+               "lite": [True, False],
+               "build_protoc_bin": [True, False]}
     default_options = {"with_zlib": False,
                        "shared": False,
                        "fPIC": True,
-                       "lite": False}
+                       "lite": False,
+                       "build_protoc_bin" : False
+                       }
 
     @property
     def _is_clang_x86(self):
@@ -30,6 +33,9 @@ class ConanFileDefault(ConanFileBase):
             if compiler_version < "14":
                 raise ConanInvalidConfiguration("On Windows Protobuf can only be built with "
                                            "Visual Studio 2015 or higher.")
+        if self.options.build_protoc_bin == True and self.options.lite == True:
+            raise ConanInvalidConfiguration("protoc binary requires full protobuf library,"
+                " it can not be build with protobuf-lite library")
 
     def requirements(self):
         if self.options.with_zlib:
@@ -39,7 +45,7 @@ class ConanFileDefault(ConanFileBase):
         cmake = CMake(self, set_cmake_flags=True)
         cmake.definitions["protobuf_BUILD_TESTS"] = False
         cmake.definitions["protobuf_WITH_ZLIB"] = self.options.with_zlib
-        cmake.definitions["protobuf_BUILD_PROTOC_BINARIES"] = not self.options.lite
+        cmake.definitions["protobuf_BUILD_PROTOC_BINARIES"] = self.options.build_protoc_bin
         cmake.definitions["protobuf_BUILD_PROTOBUF_LITE"] = self.options.lite
         if self.settings.compiler == "Visual Studio":
             cmake.definitions["protobuf_MSVC_STATIC_RUNTIME"] = "MT" in self.settings.compiler.runtime

--- a/protobuf.patch
+++ b/protobuf.patch
@@ -1,5 +1,5 @@
 diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
-index 71a0f37a..d8e16f6b 100644
+index 71a0f37aa..655ac1263 100644
 --- a/cmake/CMakeLists.txt
 +++ b/cmake/CMakeLists.txt
 @@ -33,6 +33,7 @@ option(protobuf_BUILD_TESTS "Build tests" ON)
@@ -20,155 +20,111 @@ index 71a0f37a..d8e16f6b 100644
  
    # Configure Resource Compiler
    enable_language(RC)
-@@ -213,11 +215,16 @@ if (protobuf_UNICODE)
-   add_definitions(-DUNICODE -D_UNICODE)
+@@ -214,11 +216,13 @@ if (protobuf_UNICODE)
  endif (protobuf_UNICODE)
  
--include(libprotobuf-lite.cmake)
+ include(libprotobuf-lite.cmake)
 -include(libprotobuf.cmake)
-+if (protobuf_BUILD_PROTOBUF_LITE)
-+  include(libprotobuf-lite.cmake)
-+endif (protobuf_BUILD_PROTOBUF_LITE)
-+
-+if (protobuf_BUILD_PROTOC_BINARIES OR NOT protobuf_BUILD_PROTOBUF_LITE)
+-if (protobuf_BUILD_PROTOC_BINARIES)
++if (NOT protobuf_BUILD_PROTOBUF_LITE)
 +  include(libprotobuf.cmake)
-+endif (protobuf_BUILD_PROTOC_BINARIES OR NOT protobuf_BUILD_PROTOBUF_LITE)
-+
- if (protobuf_BUILD_PROTOC_BINARIES)
++endif ()
++if (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
    include(libprotoc.cmake)
--  include(protoc.cmake)
- endif (protobuf_BUILD_PROTOC_BINARIES)
+   include(protoc.cmake)
+-endif (protobuf_BUILD_PROTOC_BINARIES)
++endif (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
  
  if (protobuf_BUILD_TESTS)
+   include(tests.cmake)
 diff --git a/cmake/install.cmake b/cmake/install.cmake
-index be47c54a..bb1e9e25 100644
+index be47c54a1..884c597f9 100644
 --- a/cmake/install.cmake
 +++ b/cmake/install.cmake
-@@ -5,7 +5,16 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf.pc.cmake
+@@ -5,10 +5,13 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf.pc.cmake
  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/protobuf-lite.pc.cmake
                 ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc @ONLY)
  
 -set(_protobuf_libraries libprotobuf-lite libprotobuf)
-+set(_protobuf_libraries)
-+
-+if (protobuf_BUILD_PROTOBUF_LITE)
-+  list(APPEND _protobuf_libraries libprotobuf-lite)
-+endif (protobuf_BUILD_PROTOBUF_LITE)
-+
+-if (protobuf_BUILD_PROTOC_BINARIES)
++set(_protobuf_libraries libprotobuf-lite)
 +if (NOT protobuf_BUILD_PROTOBUF_LITE)
-+  list(APPEND _protobuf_libraries libprotobuf)
-+endif ()
-+
- if (protobuf_BUILD_PROTOC_BINARIES)
++    list(APPEND _protobuf_libraries libprotobuf)
++endif (NOT protobuf_BUILD_PROTOBUF_LITE)
++if (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
      list(APPEND _protobuf_libraries libprotoc)
- endif (protobuf_BUILD_PROTOC_BINARIES)
-@@ -28,18 +37,6 @@ foreach(_library ${_protobuf_libraries})
+-endif (protobuf_BUILD_PROTOC_BINARIES)
++endif (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
+ 
+ foreach(_library ${_protobuf_libraries})
+   set_property(TARGET ${_library}
+@@ -28,7 +31,7 @@ foreach(_library ${_protobuf_libraries})
      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${_library})
  endforeach()
  
 -if (protobuf_BUILD_PROTOC_BINARIES)
--  install(TARGETS protoc EXPORT protobuf-targets
--    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
--  if (UNIX AND NOT APPLE)
--    set_property(TARGET protoc
--      PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
--  elseif (APPLE)
--    set_property(TARGET protoc
--      PROPERTY INSTALL_RPATH "@loader_path/../lib")
--  endif()
++if (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
+   install(TARGETS protoc EXPORT protobuf-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+   if (UNIX AND NOT APPLE)
+@@ -38,7 +41,7 @@ if (protobuf_BUILD_PROTOC_BINARIES)
+     set_property(TARGET protoc
+       PROPERTY INSTALL_RPATH "@loader_path/../lib")
+   endif()
 -endif (protobuf_BUILD_PROTOC_BINARIES)
--
++endif (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
+ 
  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/protobuf.pc ${CMAKE_CURRENT_BINARY_DIR}/protobuf-lite.pc DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
  
- file(STRINGS extract_includes.bat.in _extract_strings
-@@ -119,18 +116,10 @@ configure_file(protobuf-options.cmake
-   ${CMAKE_INSTALL_CMAKEDIR}/protobuf-options.cmake @ONLY)
+@@ -120,17 +123,22 @@ configure_file(protobuf-options.cmake
  
  # Allows the build directory to be used as a find directory.
--
+ 
 -if (protobuf_BUILD_PROTOC_BINARIES)
--  export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
--    NAMESPACE protobuf::
--    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
--  )
++if (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
+   export(TARGETS libprotobuf-lite libprotobuf libprotoc protoc
+     NAMESPACE protobuf::
+     FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+   )
 -else (protobuf_BUILD_PROTOC_BINARIES)
--  export(TARGETS libprotobuf-lite libprotobuf
--    NAMESPACE protobuf::
--    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
--  )
++elseif (protobuf_BUILD_PROTOBUF_LITE)
++  export(TARGETS libprotobuf-lite
++    NAMESPACE protobuf::
++    FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
++  )
++else ()
+   export(TARGETS libprotobuf-lite libprotobuf
+     NAMESPACE protobuf::
+     FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
+   )
 -endif (protobuf_BUILD_PROTOC_BINARIES)
-+export(TARGETS ${_protobuf_libraries}
-+  NAMESPACE protobuf::
-+  FILE ${CMAKE_INSTALL_CMAKEDIR}/protobuf-targets.cmake
-+)
++endif (protobuf_BUILD_PROTOC_BINARIES AND NOT protobuf_BUILD_PROTOBUF_LITE)
  
  install(EXPORT protobuf-targets
    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
 diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
-index fd70da7e..0f864e9b 100644
+index fd70da7e4..c3a2f17c6 100644
 --- a/cmake/libprotobuf.cmake
 +++ b/cmake/libprotobuf.cmake
-@@ -114,9 +114,46 @@ set(libprotobuf_rc_files
- )
- endif()
+@@ -116,7 +116,12 @@ endif()
  
-+set(libprotobuf_lite_files
-+  ${protobuf_source_dir}/src/google/protobuf/any_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/arena.cc
-+  ${protobuf_source_dir}/src/google/protobuf/extension_set.cc
-+  ${protobuf_source_dir}/src/google/protobuf/generated_enum_util.cc
-+  ${protobuf_source_dir}/src/google/protobuf/generated_message_table_driven_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/generated_message_util.cc
-+  ${protobuf_source_dir}/src/google/protobuf/implicit_weak_message.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/coded_stream.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/io_win32.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/strtod.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream.cc
-+   ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream_impl.cc
-+  ${protobuf_source_dir}/src/google/protobuf/io/zero_copy_stream_impl_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/message_lite.cc
-+  ${protobuf_source_dir}/src/google/protobuf/parse_context.cc
-+  ${protobuf_source_dir}/src/google/protobuf/repeated_field.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/bytestream.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/common.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/int128.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/status.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/statusor.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/stringpiece.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/stringprintf.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/structurally_valid.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/strutil.cc
-+  ${protobuf_source_dir}/src/google/protobuf/stubs/time.cc
-+  ${protobuf_source_dir}/src/google/protobuf/wire_format_lite.cc
-+)
-+
  add_library(libprotobuf ${protobuf_SHARED_OR_STATIC}
    ${libprotobuf_lite_files} ${libprotobuf_files} ${libprotobuf_includes} ${libprotobuf_rc_files})
 -target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
-+
 +string(FIND "${CMAKE_LIBRARY_ARCHITECTURE}" "arm" ARM_CROSSCOMPILING)
 +if (${ARM_CROSSCOMPILING} GREATER -1)
 +    target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT} atomic)
 +else()
 +    target_link_libraries(libprotobuf ${CMAKE_THREAD_LIBS_INIT})
 +endif()
-+
  if(protobuf_WITH_ZLIB)
      target_link_libraries(libprotobuf ${ZLIB_LIBRARIES})
  endif()
 diff --git a/cmake/protoc.cmake b/cmake/protoc.cmake
-index f90e525e..fd0c1f68 100644
+index f90e525e8..94e0d40a4 100644
 --- a/cmake/protoc.cmake
 +++ b/cmake/protoc.cmake
-@@ -2,6 +2,7 @@ set(protoc_files
-   ${protobuf_source_dir}/src/google/protobuf/compiler/main.cc
- )
- 
-+
- if (MSVC)
- set(protoc_rc_files
-   ${CMAKE_CURRENT_BINARY_DIR}/version.rc
-@@ -9,7 +10,12 @@ set(protoc_rc_files
+@@ -9,7 +9,12 @@ set(protoc_rc_files
  endif()
  
  add_executable(protoc ${protoc_files} ${protoc_rc_files})


### PR DESCRIPTION
Now it is possible to build:
 * just protobuf-lite library
 * protobuf-lite and protobuf libraries
 * protobuf-lite and protobuf libraries, and protoc binary